### PR TITLE
fix(deploymnet workflow)

### DIFF
--- a/.github/workflows/cd_google_cloud_run.yml
+++ b/.github/workflows/cd_google_cloud_run.yml
@@ -107,7 +107,6 @@ jobs:
       - name: Create .env file
         run: |
           echo "${{ secrets.ENV_VALUES }}" > .env
-          echo GAC="${{ secrets.GAC }}" >> .env
 
       - name: Deploy to Cloud Run
         id: deploy


### PR DESCRIPTION
- [x] Removed adding GAC env value to .env file in deployment workflow (GAC is only needed in docker-compose setup)